### PR TITLE
Implement unary operator for cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ open UnitsOfMeasure.Extra
 [<Measure>] type dir
 [<Measure>] type file
 
-let inline mkDir x: string<dir> = UoC.cast x
-let inline mkFile x: string<file> = UoC.cast x
+let inline mkDir x: string<dir> = %% x
+let inline mkFile x: string<file> = %% x
 
 let test (dirPath: string<dir>) (fileName: string<file>): unit =
-printfn "FULL PATH: %O/%O" dirPath fileName
+printfn "FULL PATH: %s/%s" %%dirPath %%fileName
 
 let myDir = mkDir "/my/path"
 let myFile = mkFile "file.txt"

--- a/src/UnitsOfMeasure.Extra.fs
+++ b/src/UnitsOfMeasure.Extra.fs
@@ -39,3 +39,9 @@ module UoC =
 
     /// Generic unit of measure cast function
     let inline cast (x : ^a) : ^b = _cast<UnitOfMeasureTC,^a,^b> x
+
+[<AutoOpen>]
+module Operators =
+
+    /// Generic unit of measure cast operator
+    let inline (%%) x = UoC.cast x

--- a/src/UnitsOfMeasure.Extra.fs
+++ b/src/UnitsOfMeasure.Extra.fs
@@ -44,4 +44,4 @@ module UoC =
 module Operators =
 
     /// Generic unit of measure cast operator
-    let inline (%%) x = UoC.cast x
+    let inline (~%%) x = UoC.cast x


### PR DESCRIPTION
I've added a unary operator which seems to solve the awkwardness of passing tagged strings to functions that expect the underlying values