### PR TITLE
Maximize reach wrt FSharp.Core and netcoreapp versions re #6

### DIFF
--- a/src/UnitsOfMeasure.Extra.fsproj
+++ b/src/UnitsOfMeasure.Extra.fsproj
@@ -1,11 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <PackageVersion>1.0.0-beta-005</PackageVersion>
+    <PackageVersion>1.0.0-beta-006</PackageVersion>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+    <WarningLevel>5</WarningLevel>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.1.17" />
+    <PackageReference Include="FSharp.Core" Version="3.1.2.5" Condition=" '$(TargetFramework)' == 'net45' " />
+    <PackageReference Include="FSharp.Core" Version="4.3.4" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
-</Project>
+</Project> 

--- a/tests/UnitsOfMeasure.Extra.Tests.fsproj
+++ b/tests/UnitsOfMeasure.Extra.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
I work on a project that supports `"FSharp.Core" Version="3.1.2.5"` in its `net461` variant and makes use of this in samples; relaxing the constraints as this PR does means I can compile those without warnings. I have a similar need/desire to include this in a `dotnet new` template and having maximal reach is critical in that context.

- [x] reduce .NET Core target to `netcoreapp2.1` in order to verify current LTS version works correctly
- [x] add `net461` multitargeting to tests - _I'm fine with this being removed or changed to `net45` if it proves problematic; IME `net461` targeting is commonly with default SDK/VS installs_
- [x] reduce `FSharp.Core` version requirement for `net45` to `Version="3.1.2.5"`
- [x] increase `FSharp.Core` version requirement for `netstandard2.0` to `Version="4.3.4"` (was `4.1.17`) - _happy to remove this change as TBH I'm not sure how enricosada landed on this_
- [x] up package version